### PR TITLE
Remove deprecated `bottle :unneeded` line

### DIFF
--- a/Formula/funnel.rb
+++ b/Formula/funnel.rb
@@ -3,7 +3,6 @@ class Funnel < Formula
   desc "distributed task execution toolkit"
   homepage "https://ohsu-comp-bio.github.io/funnel/"
   version "0.10.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/ohsu-comp-bio/funnel/releases/download/0.10.0/funnel-darwin-amd64-0.10.0.tar.gz"


### PR DESCRIPTION
## Overview

Resolved issue with installing Funnel view Homebrew (previously mentioned: https://github.com/ohsu-comp-bio/homebrew-formula/pull/2#issuecomment-1788002355):

> Possible issue with the current formula: https://github.com/goreleaser/goreleaser/pull/2591
> 
> Removing the bottle :unneeded line resolves the issue and allows brew install --build-from-source ./Formula/funnel.rb to install Funnel successfully with the existing Formula.

## Current Behavior ❌

```sh
brew install funnel
==> Downloading https://formulae.brew.sh/api/formula.jws.json
###################################################################################################################################################################################### 100.0%
==> Downloading https://formulae.brew.sh/api/cask.jws.json
###################################################################################################################################################################################### 100.0%
Error: funnel: wrong number of arguments (given 1, expected 0)
```

## New Behavior ✅

```sh
➜ brew install --build-from-source ./Formula/funnel.rb
==> Downloading https://formulae.brew.sh/api/formula.jws.json

Error: Failed to load cask: ./Formula/funnel.rb
Cask 'funnel' is unreadable: wrong constant name #<Class:0x00000001337c61e8>
Warning: Treating ./Formula/funnel.rb as a formula.
==> Fetching funnel
==> Downloading https://github.com/ohsu-comp-bio/funnel/releases/download/0.10.0/funnel-darwin-amd64-0.10.0.tar.gz
Already downloaded: /Users/beckmanl/Library/Caches/Homebrew/downloads/f80b7445acd94b85d726e78a44a0cb9c05bd9ce274e8f4076f3176575a18fe57--funnel-darwin-amd64-0.10.0.tar.gz
==> Downloading https://formulae.brew.sh/api/cask.jws.json

🍺  /opt/homebrew/Cellar/funnel/0.10.0: 5 files, 72.9MB, built in 2 seconds
==> Running `brew cleanup funnel`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

➜ which funnel
/opt/homebrew/bin/funnel

➜ funnel version
git commit: b906ba8d
git branch: master
git upstream: git@github.com:ohsu-comp-bio/funnel.git
build date: 2020-03-27T18:00:28Z
version: 0.10.0
```

